### PR TITLE
Change `Debug` to use string representation

### DIFF
--- a/src/id.rs
+++ b/src/id.rs
@@ -12,7 +12,7 @@ const ENC: &[u8] = "0123456789abcdefghijklmnopqrstuv".as_bytes();
 const DEC: [u8; 256] = gen_dec();
 
 /// An ID.
-#[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Clone, Copy, Hash)]
+#[derive(PartialEq, Eq, PartialOrd, Ord, Clone, Copy, Hash)]
 pub struct Id(pub [u8; RAW_LEN]);
 
 impl Id {
@@ -81,6 +81,12 @@ impl ToString for Id {
         bs[1] = ENC[(((raw[1] >> 6) | (raw[0] << 2)) & 31) as usize];
         bs[0] = ENC[(raw[0] >> 3) as usize];
         str::from_utf8(&bs).unwrap().to_string()
+    }
+}
+
+impl std::fmt::Debug for Id {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_tuple("Id").field(&self.to_string()).finish()
     }
 }
 


### PR DESCRIPTION
Hi! I've been using xid for a few months and it works great, thanks for this!

However, I find myself struggling now that I've started debugging my program more often. Even though `Id` implements debug, it prints the raw bytes, which is not human-friendly at all when debugging and creates a lot of noise.

This PR just adds a manual implementation so that it prints the string